### PR TITLE
Move student and teaching cohorts to CohortUser scopes

### DIFF
--- a/app/models/cohort_user.rb
+++ b/app/models/cohort_user.rb
@@ -3,4 +3,7 @@ class CohortUser < ApplicationRecord
   belongs_to :cohort
 
   enum role: ["student", "instructor"]
+
+  scope :student_cohort, -> { where(role: "student").first.cohort }
+  scope :teaching_cohort, -> { where(role: "instructor").first.cohort }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,10 +21,10 @@ class User < ApplicationRecord
   end
 
   def cohort
-    cohort_users.where(role: "student").first.cohort
+    cohort_users.student_cohort
   end
 
   def teaching
-    cohort_users.where(role: "instructor").first.cohort
+    cohort_users.teaching_cohort
   end
 end


### PR DESCRIPTION
@notmarkmiranda Thoughts? Is there a better way to do this that I'm not considering?

Overall the idea here is that a teacher who was previously a student would retain their relationship to their cohort through the `cohort_users` join with a row labeled as `role: "student"`, but then could also have a class that they're currently teaching with a new entry on the same join labeled as `role: "teacher"`.

Refactor in this PR moves some of the logic for this relationship to the join itself, but trying to determine if I think it's actually better.

One other alternative I'm considering:

```ruby
# user.rb
def cohort
  cohort_users.students.first.cohort
end

def teaching
  cohort_users.teachers.first.cohort
end

# cohort_user.rb
scope :students, -> { where(role: "student") }
scope :teachers, -> { where(role: "teacher") }
```

I suppose another alternative would be to create two separate tables (`teachers` and `students`?) to represent the different relationships between users and cohorts. Might allow me to use more of the built-in ActiveRecord functionality? Believe I would still need to be a little clever with my `has_many through` on the user side (see what I've done already with users and projects).

That might be the way to go. Two issues that I see with the current schema:

1) Having to use two queries to get a student's cohort/teacher's cohort.
2) Think I'll have to define a custom `cohort=` method to account for trying to re-set a student's cohort. Currently `cohort` returns a Cohort object, but AR isn't playing nicely with the underlying relationship.