### PR TITLE
Rename reflection tables

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,12 +1,12 @@
-class ReflectionResponsesController < ApplicationController
+class ResponsesController < ApplicationController
   def new
     @project = Project.find(params[:project_id])
   end
 
   def create
     @project   = Project.find(params[:project_id])
-    responses = create_responses(params[:reflection_questions])
-    if ReflectionResponse.create(responses)
+    responses = create_responses(params[:questions])
+    if Response.create(responses)
       redirect_to user_path(current_user)
     else
       flash[:error] = "Something went wrong. Try again."

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,18 +1,18 @@
 class Project < ApplicationRecord
   has_many :assignments
   has_many :users, through: :assignments
-  has_many :reflection_questions
-  has_many :prompts, through: :reflection_questions
-  has_many :reflection_responses
-  has_many :responded_users, through: :reflection_responses, source: :user
+  has_many :questions
+  has_many :prompts, through: :questions
+  has_many :responses
+  has_many :responded_users, through: :responses, source: :user
 
   def user_response?(user)
     responded_users.include?(user)
   end
 
   def safe_response(user, prompt)
-    reflection = reflection_responses.find_by(user: user, prompt: prompt)
+    response = responses.find_by(user: user, prompt: prompt)
 
-    reflection ? reflection.response : ""
+    response ? response.response : ""
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,4 @@
-class ReflectionQuestion < ApplicationRecord
+class Question < ApplicationRecord
   belongs_to :project
   belongs_to :prompt
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -1,4 +1,4 @@
-class ReflectionResponse < ApplicationRecord
+class Response < ApplicationRecord
   belongs_to :user
   belongs_to :project
   belongs_to :prompt

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :assigned_projects, through: :assignments, source: :project
   belongs_to :cohort, required: false
   belongs_to :instructor_cohort, class_name: "Cohort", required: false
-  has_many :reflection_responses
+  has_many :responses
 
   validates :name, presence: true
 

--- a/app/views/reflection_responses/edit.html.erb
+++ b/app/views/reflection_responses/edit.html.erb
@@ -1,9 +1,0 @@
-<h1><%= @project.name %></h1>
-
-<%= form_tag "/projects/#{@project.id}/reflection_responses" do %>
-  <% @project.reflection_questions.each do |reflection_question| %>
-    <%= label_tag("reflection_questions[#{reflection_question.prompt_id}]", reflection_question.prompt.prompt) %><br />
-    <%= text_area_tag("reflection_questions[#{reflection_question.prompt_id}]", @project.safe_response(@current_user, reflection_question.prompt), cols: "120", rows: "20") %><br />
-  <% end %>
-  <%= submit_tag "Update" %>
-<% end %>

--- a/app/views/reflection_responses/new.html.erb
+++ b/app/views/reflection_responses/new.html.erb
@@ -1,9 +1,0 @@
-<h1><%= @project.name %></h1>
-
-<%= form_tag "/projects/#{@project.id}/reflection_responses" do %>
-  <% @project.reflection_questions.each do |reflection_question| %>
-    <%= label_tag("reflection_questions[#{reflection_question.prompt_id}]", reflection_question.prompt.prompt) %><br />
-    <%= text_area_tag("reflection_questions[#{reflection_question.prompt_id}]", nil, cols: "120", rows: "20") %><br />
-  <% end %>
-  <%= submit_tag "Create" %>
-<% end %>

--- a/app/views/responses/edit.html.erb
+++ b/app/views/responses/edit.html.erb
@@ -1,0 +1,9 @@
+<h1><%= @project.name %></h1>
+
+<%= form_tag "/projects/#{@project.id}/responses" do %>
+  <% @project.questions.each do |question| %>
+    <%= label_tag("questions[#{question.prompt_id}]", question.prompt.prompt) %><br />
+    <%= text_area_tag("questions[#{question.prompt_id}]", @project.safe_response(@current_user, question.prompt), cols: "120", rows: "20") %><br />
+  <% end %>
+  <%= submit_tag "Update" %>
+<% end %>

--- a/app/views/responses/new.html.erb
+++ b/app/views/responses/new.html.erb
@@ -1,0 +1,9 @@
+<h1><%= @project.name %></h1>
+
+<%= form_tag "/projects/#{@project.id}/responses" do %>
+  <% @project.questions.each do |question| %>
+    <%= label_tag("questions[#{question.prompt_id}]", question.prompt.prompt) %><br />
+    <%= text_area_tag("questions[#{question.prompt_id}]", nil, cols: "120", rows: "20") %><br />
+  <% end %>
+  <%= submit_tag "Create" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,9 +14,9 @@
       </td>
       <td>
         <% if project.user_response?(@user) %>
-          <%= link_to "Update", edit_project_reflection_responses_path(project) %>
+          <%= link_to "Update", edit_project_responses_path(project) %>
         <% else %>
-          <%= link_to "Create", new_project_reflection_responses_path(project) %>
+          <%= link_to "Create", new_project_responses_path(project) %>
         <% end %>
       </td>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :users, only: [:show]
   resources :assignments, only: [:new, :create]
   resources :projects, only: [:new, :create] do
-    resource :reflection_responses, only: [:new, :create, :edit, :update]
+    resource :responses, only: [:new, :create, :edit, :update]
   end
 
   get '/auth/:provider/callback', to: 'sessions#create', as: 'login'

--- a/db/migrate/20170815030448_rename_reflection_questions_to_questions.rb
+++ b/db/migrate/20170815030448_rename_reflection_questions_to_questions.rb
@@ -1,0 +1,5 @@
+class RenameReflectionQuestionsToQuestions < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :reflection_questions, :questions
+  end
+end

--- a/db/migrate/20170815030535_rename_reflection_responses_to_responses.rb
+++ b/db/migrate/20170815030535_rename_reflection_responses_to_responses.rb
@@ -1,0 +1,5 @@
+class RenameReflectionResponsesToResponses < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :reflection_responses, :responses
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170815022816) do
+ActiveRecord::Schema.define(version: 20170815030535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,23 +38,23 @@ ActiveRecord::Schema.define(version: 20170815022816) do
     t.string "prompt"
   end
 
-  create_table "reflection_questions", force: :cascade do |t|
+  create_table "questions", force: :cascade do |t|
     t.bigint "project_id"
     t.bigint "prompt_id"
-    t.index ["project_id"], name: "index_reflection_questions_on_project_id"
-    t.index ["prompt_id"], name: "index_reflection_questions_on_prompt_id"
+    t.index ["project_id"], name: "index_questions_on_project_id"
+    t.index ["prompt_id"], name: "index_questions_on_prompt_id"
   end
 
-  create_table "reflection_responses", force: :cascade do |t|
+  create_table "responses", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "project_id"
     t.bigint "prompt_id"
     t.string "response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["project_id"], name: "index_reflection_responses_on_project_id"
-    t.index ["prompt_id"], name: "index_reflection_responses_on_prompt_id"
-    t.index ["user_id"], name: "index_reflection_responses_on_user_id"
+    t.index ["project_id"], name: "index_responses_on_project_id"
+    t.index ["prompt_id"], name: "index_responses_on_prompt_id"
+    t.index ["user_id"], name: "index_responses_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -76,9 +76,9 @@ ActiveRecord::Schema.define(version: 20170815022816) do
 
   add_foreign_key "assignments", "projects"
   add_foreign_key "assignments", "users"
-  add_foreign_key "reflection_questions", "projects"
-  add_foreign_key "reflection_questions", "prompts"
-  add_foreign_key "reflection_responses", "projects"
-  add_foreign_key "reflection_responses", "prompts"
-  add_foreign_key "reflection_responses", "users"
+  add_foreign_key "questions", "projects"
+  add_foreign_key "questions", "prompts"
+  add_foreign_key "responses", "projects"
+  add_foreign_key "responses", "prompts"
+  add_foreign_key "responses", "users"
 end

--- a/spec/features/authenticated_user_spec.rb
+++ b/spec/features/authenticated_user_spec.rb
@@ -60,12 +60,12 @@ describe "An authenticated user" do
     visit user_path(student)
     click_on "Create"
 
-    fill_in "reflection_questions[#{credit.prompts.first.id}]", with: "first"
-    fill_in "reflection_questions[#{credit.prompts.second.id}]", with: "second"
+    fill_in "questions[#{credit.prompts.first.id}]", with: "first"
+    fill_in "questions[#{credit.prompts.second.id}]", with: "second"
     click_on "Create"
 
-    expect(ReflectionResponse.first.response).to eq("first")
-    expect(ReflectionResponse.second.response).to eq("second")
+    expect(Response.first.response).to eq("first")
+    expect(Response.second.response).to eq("second")
     expect(page).to_not have_content("Create")
     expect(page).to have_content("Update")
   end
@@ -75,18 +75,18 @@ describe "An authenticated user" do
     credit   = student.assigned_projects.create(name: "Credit Check")
     prompt_1 = credit.prompts.create(prompt: "What did you learn from this project?")
     prompt_2 = credit.prompts.create(prompt: "What did you struggle with this project?")
-    student.reflection_responses.create(prompt: prompt_1, project: credit, response: "first")
+    student.responses.create(prompt: prompt_1, project: credit, response: "first")
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(student)
 
     visit user_path(student)
     click_on "Update"
 
-    fill_in "reflection_questions[#{credit.prompts.second.id}]", with: "second"
+    fill_in "questions[#{credit.prompts.second.id}]", with: "second"
     click_on "Update"
 
-    expect(ReflectionResponse.find_by(prompt: prompt_1).response).to eq("first")
-    expect(ReflectionResponse.find_by(prompt: prompt_2).response).to eq("second")
+    expect(Response.find_by(prompt: prompt_1).response).to eq("first")
+    expect(Response.find_by(prompt: prompt_2).response).to eq("second")
     expect(page).to_not have_content("Create")
     expect(page).to have_content("Update")
   end


### PR DESCRIPTION
Renamed `reflection_responses` and `reflection_questions` to `responses` and `questions` respectively.

Associated changes:

* Rename tables.
* Update Model/Controller names.
* Update relationships in models.
* Update Controller create method.
* Update views.
* Update routes.
* Update authenticated user spec.